### PR TITLE
Split shapes graph from ontologygraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generates datamodel documentation from SHACL and/or RDFS files.
 ```bash
 usage: shacl2md.py [-h] [--language [language [language ...]]] [--out out] [--parent parent] [--layout layout]
                [--nav_order nav_order] [--name name] [--crosslinks [crosslinks [crosslinks ...]]] [--vdir]
-               [--validate] [--nodocs]
+               [--validate] [--nodocs] [--ontology rdfsFile [rdfsFile ...]]
                inputFile [inputFile ...]
 
 ```
@@ -14,13 +14,14 @@ usage: shacl2md.py [-h] [--language [language [language ...]]] [--out out] [--pa
 
 |Option|Default|Description|
 | :--- | :--- | :--- |
-|`files`|`None`|SHACL OR RDFS files to construct Markdown documentation of.|
+|`files`|`None`|SHACL shape files to construct Markdown documentation of|
 
 # Optional Arguments
 
 |Option|Default|Description|
 | :--- | :--- | :--- |
 |`-h`, `--help`||show this help message and exit|
+|`--ontology`|`[]`|RDFS files that provide extra ontological information with the SHACL files|
 |`--language`|`['nl']`|languages of generated documentation, default is "nl"|
 |`--out`|`./`|output directory for files, default is "./"|
 |`--parent`|`index`|Jekyll parent page, default is "index"|
@@ -29,5 +30,5 @@ usage: shacl2md.py [-h] [--language [language [language ...]]] [--out out] [--pa
 |`--name`|`output`|filename for the output file, default is "output"|
 |`--crosslinks`|`None`|crosslink graphs to find classes in: format is "name1=file1,file2,... name2=file1,file2,..."|
 |`--vdir`||if present, outputs files to a directory based on the SHACL version|
-|`--validate`||if present, the shacl file is validated against the SHACL-SHACL.|
-|`--nodocs`||if present, only a diagram is produced.|
+|`--validate`||if present, the shacl file is validated against the SHACL-SHACL|
+|`--nodocs`||if present, only a diagram is produced|

--- a/queries.py
+++ b/queries.py
@@ -14,6 +14,7 @@ WHERE {
         FILTER(lang(?description) = ?lang)
     }
 }
+LIMIT 1
 """
 
 
@@ -212,6 +213,7 @@ WHERE {
     } 
 }
 """
+
 CLASS_EXISTS_CHECK = """
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sh: <http://www.w3.org/ns/shacl#> 

--- a/shacl2md.py
+++ b/shacl2md.py
@@ -451,13 +451,13 @@ def main(args):
     print(f"Creating {args.name}")
     print("-----------------------------------------------")
 
-    g = Graph()
+    g = Graph(bind_namespaces="none")
     print(f"Shape files:")
     for file in args.files:
         print(f"- {file}")
         g.parse(file)
 
-    g_ont = Graph()
+    g_ont = Graph(bind_namespaces="none")
     print(f"Ontology files:")
     for ont_file in args.ontology:
         print(f"- {ont_file}")


### PR DESCRIPTION
When using 2 ontologies, like with SKOS & SKOS-XL, the version number cannot be identified correctly. Therefore, the  the SHACL shapes graph and the RDFS ontology graph need to split. The `get_docs` query is only executed on the shapes graph.